### PR TITLE
Update ssversion2005-md.md

### DIFF
--- a/docs/includes/ssversion2005-md.md
+++ b/docs/includes/ssversion2005-md.md
@@ -1,1 +1,1 @@
- Resultado de 
+ SQL Server 2005 


### PR DESCRIPTION
The original "SQL Server 2005" was translated into "Resultado de", which is completely incorrect and was producing weird results in the pages where it is included.