### PR TITLE
Clarify parameters meaning

### DIFF
--- a/docs/t-sql/functions/replace-transact-sql.md
+++ b/docs/t-sql/functions/replace-transact-sql.md
@@ -47,7 +47,7 @@ REPLACE ( string_expression , string_pattern , string_replacement )
  Es la [expresión](../../t-sql/language-elements/expressions-transact-sql.md) de cadena que se va a buscar. *string_expression* puede ser de un tipo de datos binario o de caracteres.  
   
  *string\_pattern*  
- Es la subcadena a encontrar. *string_pattern* puede ser de un tipo de datos binario o de caracteres. *string_pattern* no puede ser una cadena vacía ('') y no debe superar el número máximo de bytes que cabe en una página.  
+ Es la subcadena que se va a encontrar. *string_pattern* puede ser de un tipo de datos binario o de caracteres. *string_pattern* no puede ser una cadena vacía ('') y no debe superar el número máximo de bytes que cabe en una página.
   
  *string\_replacement*  
  Es la cadena de reemplazo. *string_replacement* puede tener un tipo de datos de carácter o binario.  

--- a/docs/t-sql/functions/replace-transact-sql.md
+++ b/docs/t-sql/functions/replace-transact-sql.md
@@ -47,7 +47,7 @@ REPLACE ( string_expression , string_pattern , string_replacement )
  Es la [expresión](../../t-sql/language-elements/expressions-transact-sql.md) de cadena que se va a buscar. *string_expression* puede ser de un tipo de datos binario o de caracteres.  
   
  *string\_pattern*  
- Es la subcadena que se va a buscar. *string_pattern* puede ser de un tipo de datos binario o de caracteres. *string_pattern* no puede ser una cadena vacía ('') y no debe superar el número máximo de bytes que cabe en una página.  
+ Es la subcadena a encontrar. *string_pattern* puede ser de un tipo de datos binario o de caracteres. *string_pattern* no puede ser una cadena vacía ('') y no debe superar el número máximo de bytes que cabe en una página.  
   
  *string\_replacement*  
  Es la cadena de reemplazo. *string_replacement* puede tener un tipo de datos de carácter o binario.  


### PR DESCRIPTION
Con la traducción actual no se diferencian los parametros

tanto "to be searched" como "to be found" se han traducido como "que se va a buscar", haciendo dificil entender cada parametro. 
dado que se rechaza cambiar "to be searched" por "en la que se va a buscar", propongo cambiar la traducción del otro parametro por "a encontrar"