### PR TITLE
Translate a link that was previously untranslated

### DIFF
--- a/docs/relational-databases/collations/set-or-change-the-server-collation.md
+++ b/docs/relational-databases/collations/set-or-change-the-server-collation.md
@@ -65,7 +65,7 @@ Si va a migrar bases de datos de SQL Server a Instancia administrada, compruebe 
 
 ## <a name="see-also"></a>Consulte también
 
- [Collation and Unicode Support](../../relational-databases/collations/collation-and-unicode-support.md)   
+ [Compatibilidad con la intercalación y Unicode](../../relational-databases/collations/collation-and-unicode-support.md)   
  [Establecer o cambiar la intercalación de base de datos](../../relational-databases/collations/set-or-change-the-database-collation.md)   
  [Establecer o cambiar la intercalación de columnas](../../relational-databases/collations/set-or-change-the-column-collation.md)   
  [Volver a generar bases de datos del sistema](../../relational-databases/databases/rebuild-system-databases.md)  


### PR DESCRIPTION
The link does point to the translated version of the page, but the text of the link was in English instead of matching the title of the translated page.


