### PR TITLE
Update operator-precedence-transact-sql.md

### DIFF
--- a/docs/t-sql/language-elements/operator-precedence-transact-sql.md
+++ b/docs/t-sql/language-elements/operator-precedence-transact-sql.md
@@ -39,7 +39,7 @@ ms.locfileid: "98100984"
 |3|+ (positivo), - (negativo), + (suma), + (concatenación), - (resta), & (AND bit a bit), ^ (OR exclusivo bit a bit), &#124; (OR bit a bit)|  
 |4|=, >, \<, >=, <=, <>, !=, !>, !< (operadores de comparación)|  
 |5|NOT|  
-|6|y|  
+|6|AND|  
 |7|ALL, ANY, BETWEEN, IN, LIKE, OR, SOME|  
 |8|= (asignación)|  
   


### PR DESCRIPTION
Eliminar la traducción del Operador `AND` puesto que los operdores no deben ser traducidos.